### PR TITLE
Install Wrapland from artifact

### DIFF
--- a/.github/actions/dep-artifact-generic/action.yml
+++ b/.github/actions/dep-artifact-generic/action.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 name: Install Dependency via Artifact
-description: Uses deb package from other workflow to install on Arch
+description: Uses tar package from other workflow to install on Arch
 inputs:
   repo:
     description: Path to repo where to download the dependency from
@@ -32,9 +32,5 @@ runs:
       run: tar -xf ${{ inputs.dep-name }}.tar.gz
       shell: bash
     - name: Install
-      run: cp -r como/* /usr
-      shell: bash
-    - run: ls -l /usr/bin/minico
-      shell: bash
-    - run: ls -l /usr/include/como/base
+      run: cp -r ${{ inputs.dep-name }}/* /usr
       shell: bash

--- a/.github/actions/dep-artifacts/action.yml
+++ b/.github/actions/dep-artifacts/action.yml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2024 Roman Gilg <subdiff@gmail.com>
+# SPDX-License-Identifier: MIT
+name: Specialized Install Dependency via Artifact
+description: Calls into more generic dep-artifact-generic to install dependency
+inputs:
+  secret:
+    description: Secret
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Install Wrapland
+      uses: ./.github/actions/dep-artifact-generic
+      with:
+        repo: winft/wrapland
+        dep-name: wrapland
+        secret: ${{ inputs.secret }}
+    - name: Install The Compositor Modules
+      uses: ./.github/actions/dep-artifact-generic
+      with:
+        repo: winft/como
+        dep-name: como
+        secret: ${{ inputs.secret }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,12 +69,9 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-      - name: Install como
-        uses: ./.github/actions/dep-artifact
+      - name: Install Dependencies
+        uses: ./.github/actions/dep-artifacts
         with:
-          repo: winft/como
-          branch: master
-          dep-name: como
           secret: ${{ secrets.GITHUB_TOKEN }}
       - run: mkdir build
       - name: Configure


### PR DESCRIPTION
The image does not contain any longer Wrapland. Instead install it directly from the latest artifact.