### PR TITLE
Adapt to COMO screen locker change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,7 @@ kcoreaddons_target_static_plugins(kwin_x11 NAMESPACE "kwin/effects/plugins")
 
 add_executable(kwin_wayland main_wayland.cpp)
 target_link_libraries(kwin_wayland
-  como::desktop-kde
+  como::desktop-kde-wl
   como::script
   como::wayland
   como::xwayland

--- a/main_wayland.cpp
+++ b/main_wayland.cpp
@@ -9,6 +9,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <como/base/wayland/app_singleton.h>
 #include <como/base/wayland/xwl_platform.h>
 #include <como/desktop/kde/platform.h>
+#include <como/desktop/kde/screen_locker.h>
 #include <como/render/shortcuts_init.h>
 #include <como/script/platform.h>
 #include <como/win/shortcuts_init.h>
@@ -247,7 +248,9 @@ int main(int argc, char* argv[])
         base.process_environment.insert(QStringLiteral("WAYLAND_DISPLAY"), name.c_str());
     }
 
-    base.server->init_screen_locker();
+    base.mod.space->mod.desktop->screen_locker
+        = std::make_unique<como::desktop::kde::screen_locker>(
+            *base.server, base.process_environment, parser.isSet(options.lockscreen));
 
     if (base.operation_mode == como::base::operation_mode::xwayland) {
         try {


### PR DESCRIPTION
COMO interface for the screen locker changes, this includes a change of the library name for Wayland compositors.